### PR TITLE
Update to support 0.219.16

### DIFF
--- a/Auto Map Pins Configurable.sln
+++ b/Auto Map Pins Configurable.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31019.35
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35506.116 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AMP_Configurable", "Auto Map Pins Configurable\AMP_Configurable.csproj", "{5C1A1606-C579-4934-BED8-641C16F4848A}"
 EndProject

--- a/Auto Map Pins Configurable/AMP_Configurable.csproj
+++ b/Auto Map Pins Configurable/AMP_Configurable.csproj
@@ -36,15 +36,19 @@
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>..\Valheim\BepInEx\core\0Harmony.dll</HintPath>
+	  <HintPath>$(VALHEIM)\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="assembly_utils">
       <HintPath>..\Valheim\valheim_Data\Managed\assembly_utils.dll</HintPath>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\assembly_utils.dll</HintPath>
     </Reference>
     <Reference Include="assembly_valheim">
       <HintPath>..\Valheim\valheim_Data\Managed\assembly_valheim.dll</HintPath>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\assembly_valheim.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
       <HintPath>..\Valheim\BepInEx\core\BepInEx.dll</HintPath>
+	  <HintPath>$(VALHEIM)\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.dll</HintPath>
@@ -71,32 +75,39 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="ui_lib">
-      <HintPath>..\Valheim\valheim_Data\Managed\ui_lib.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
+    <Reference Include="gui_framework">
+	  <HintPath>..\Valheim\valheim_Data\Managed\gui_framework.dll</HintPath>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\gui_framework.dll</HintPath>
+	</Reference>
+	<Reference Include="Unity.TextMeshPro">
       <HintPath>..\Valheim\valheim_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+	</Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\UnityEngine.dll</HintPath>
+	</Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+	</Reference>
     <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
-    </Reference>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+	</Reference>
     <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-    </Reference>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+	</Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
+	  <HintPath>$(VALHEIM)\valheim_Data\Managed\UnityEngine.UI.dll</HintPath>
+	</Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AMP_Configurable.cs" />
@@ -123,14 +134,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="Copy" AfterTargets="ILRepack">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\Users\Jordan\AppData\Roaming\r2modmanPlus-local\Valheim\profiles\Dev\BepInEx\plugins\raziell74-AMPED_Auto_Map_Pins_Enhanced\&quot; /q /y /i" />
     <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ProjectDir)\bin\Release\AMPED-AutoMapPinsEnhanced_v1.3.6\plugins\&quot; /q /y /i" />
   </Target>
   <PropertyGroup>
     <PostBuildEvent>
-xcopy "$(ProjectDir)\AMP_Enhanced\amp_pin_types.json" "C:\Users\Jordan\AppData\Roaming\r2modmanPlus-local\Valheim\profiles\Dev\BepInEx\plugins\raziell74-AMPED_Auto_Map_Pins_Enhanced\AMP_Enhanced\" /q /y /i
-xcopy "$(ProjectDir)\AMP_Enhanced\pin-icons" "C:\Users\Jordan\AppData\Roaming\r2modmanPlus-local\Valheim\profiles\Dev\BepInEx\plugins\raziell74-AMPED_Auto_Map_Pins_Enhanced\AMP_Enhanced\pin-icons\" /c /q /y /i
-
 xcopy "$(ProjectDir)\AMP_Enhanced\amp_pin_types.json" "$(ProjectDir)\bin\Release\AMPED-AutoMapPinsEnhanced_v1.3.6\plugins\AMP_Enhanced\" /q /y /i
 xcopy "$(ProjectDir)\AMP_Enhanced\pin-icons" "$(ProjectDir)\bin\Release\AMPED-AutoMapPinsEnhanced_v1.3.6\plugins\AMP_Enhanced\pin-icons" /c /q /y /i
 xcopy "$(ProjectDir)\..\icon.png" "$(ProjectDir)\bin\Release\AMPED-AutoMapPinsEnhanced_v1.3.6\" /q /y /i

--- a/Auto Map Pins Configurable/AMP_Configurable.csproj
+++ b/Auto Map Pins Configurable/AMP_Configurable.csproj
@@ -9,11 +9,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AMP_Configurable</RootNamespace>
     <AssemblyName>AMP_Configurable</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,18 +35,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>..\Valheim\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="assembly_utils, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\valheim_Data\Managed\assembly_utils.dll</HintPath>
+    <Reference Include="assembly_utils">
+      <HintPath>..\Valheim\valheim_Data\Managed\assembly_utils.dll</HintPath>
     </Reference>
-    <Reference Include="assembly_valheim, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\valheim_Data\Managed\assembly_valheim.dll</HintPath>
+    <Reference Include="assembly_valheim">
+      <HintPath>..\Valheim\valheim_Data\Managed\assembly_valheim.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>..\Valheim\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.dll</HintPath>
@@ -72,25 +71,31 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="ui_lib">
+      <HintPath>..\Valheim\valheim_Data\Managed\ui_lib.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>..\Valheim\valheim_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\unstripped_corlib\UnityEngine.dll</HintPath>
+      <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\unstripped_corlib\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\unstripped_corlib\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\unstripped_corlib\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Steam\steamapps\common\Valheim\unstripped_corlib\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\Valheim\valheim_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Auto Map Pins Configurable/app.config
+++ b/Auto Map Pins Configurable/app.config
@@ -8,4 +8,5 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+  <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup>
+</configuration>

--- a/Auto Map Pins Configurable/app.config
+++ b/Auto Map Pins Configurable/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Mono.Cecil" publicKeyToken="50cebf1cceb9d05e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.11.1.0" newVersion="0.11.1.0" />
+        <assemblyIdentity name="Mono.Cecil" publicKeyToken="50cebf1cceb9d05e" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-0.11.1.0" newVersion="0.11.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Change Log.md
+++ b/Change Log.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### Version v1.3.6
+  * Support for build 0.219.16
+
 ### Version v1.3.5
   * Performance Overhaul! Updated and refactored a large portion of the mod to run faster as to not cause as much FPS drops for potato computers. Lots of legacy code updated.
   * Updated and reorganized configuration. My sincerest apologies but this will require you to redo your configuration settings, my first go at it a lot of the naming is bad and would cause issues and I now know a ton more about the inner workings of BepInEx configurations. If you experience issues, delete your `amped.mod.auto_map_pins.cfg` and restart the game to generate a clean config. Thank you for your patience, this is my first time doing any BepInEx modding.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Contibutions from the following modders was invaluable and appreciated:
 
 # Change Log
 
+### Version v1.3.6
+  * Support for build 0.219.16
+
 ### Version v1.3.5
   * Performance Overhaul! Updated and refactored a large portion of the mod to run faster as to not cause as much FPS drops for potato computers. Lots of legacy code updated.
   * Updated and reorganized configuration. My sincerest apologies but this will require you to redo your configuration settings, my first go at it a lot of the naming is bad and would cause issues and I now know a ton more about the inner workings of BepInEx configurations. If you experience issues, delete your `amped.mod.auto_map_pins.cfg` and restart the game to generate a clean config. Thank you for your patience, this is my first time doing any BepInEx modding.


### PR DESCRIPTION
This updates the solution files to build for release 0.219.16 and adds some small fixes to make building this project more approachable to others.

All Valheim and BepIn libraries are now referenced by an environment variable (`$(VALHEIM)`) that can be set to where the game is installed.  This follows how [Vintage Story](https://wiki.vintagestory.at/index.php/Modding:Preparing_For_Code_Mods#Creating_an_Environment_Variable) deals with code mods in a semi-portable manner.  The older `HintPath`s are still in place and should continue to work.

This includes changes from #12, as those are were needed and yet unreleased to date. 

This is my locally built, and tested, version: 
[AMPED-AutoMapPinsEnhanced_v1.3.6.zip](https://github.com/user-attachments/files/17758616/AMPED-AutoMapPinsEnhanced_v1.3.6.zip)

Closes #12 